### PR TITLE
Release 高校保健 一問一答 iOS 1.0.1 (Build 98)

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -24,6 +24,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Health Quiz App</string>
+	<string>高校保健 一問一答</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>health_quiz_app</string>
+	<string>高校保健 一問一答</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: health_quiz_app
 description: "A new Flutter project."
 publish_to: "none"
 
-version: 1.0.0+97
+version: 1.0.1+98
 
 environment:
   sdk: ">=3.4.0 <4.0.0"


### PR DESCRIPTION
## 概要

高校保健 一問一答 iOS 1.0.1（Build 98）のリリースPRです。

## App Store提出情報

- Version: 1.0.1
- Build: 98
- Bundle ID: jp.mokeke.healthquiz
- 提出コミット: 96b61c9
- App Review提出済み: 2026-07-31

## 変更内容

- サポート情報とプライバシーポリシー案内の更新
- ITSAppUsesNonExemptEncryption=falseを追加
- iOS端末上の表示名を「高校保健 一問一答」へ統一

## 確認結果

- flutter analyze: errorなし
- 既存warning・info: 82件
- flutter test: 全テスト合格
- App Store用IPA生成: 成功
- 正式な日本語表示名を確認済み

## マージ方針

Appleの審査承認後にマージする。
静的解析の既存警告は別課題として扱う。